### PR TITLE
Forcing function to always return array to avoid php7.2 count warning.

### DIFF
--- a/code/Debug/Model/Observer.php
+++ b/code/Debug/Model/Observer.php
@@ -46,13 +46,16 @@ class Magneto_Debug_Model_Observer {
         return false;
     }
 
+    /**
+     * @return array
+     */
 	public function getQueries() {
 		//TODO: implement profiler for connections other than 'core_write'  
 		$profiler = Mage::getSingleton('core/resource')->getConnection('core_write')->getProfiler();
 		$queries = array();
 		
 		if( $profiler ) {
-			$queries = $profiler->getQueryProfiles();
+			$queries = $profiler->getQueryProfiles() ?: array();
 		}
 		
 		return $queries;


### PR DESCRIPTION
Solves PHP7.2 problem:
Warning: count(): Parameter must be an array or an object that implements Countable in /app/code/community/Magneto/Debug/Block/Debug.php on line 134